### PR TITLE
Fix a coverity issue "Non-array delete for scalars"

### DIFF
--- a/src/output_dynamic.cpp
+++ b/src/output_dynamic.cpp
@@ -37,7 +37,7 @@ output_dynamic::output_dynamic(unsigned int inital_capacity) {
 }
 
 output_dynamic::~output_dynamic() {
-    delete _buffer;
+    delete[] _buffer;
 }
 
 unsigned char *output_dynamic::data() {


### PR DESCRIPTION
Coverity says:
```
Undefined behavior might result; however most implementations will work.

In mozilla::​dom::​CBOREncodePublicKeyObj(mozilla::​dom::​CryptoBuffer const &, mozilla::​dom::​CryptoBuffer &): Using non-array delete on an array of scalars or pointers allocated with new[] (CWE-459)
```