### PR TITLE
Memory allocated with new[] should be freed with delete[]

### DIFF
--- a/src/output_static.cpp
+++ b/src/output_static.cpp
@@ -28,7 +28,7 @@ output_static::output_static(unsigned int capacity) {
 }
 
 output_static::~output_static() {
-    delete _buffer;
+    delete[] _buffer;
 }
 
 void output_static::put_byte(unsigned char value) {


### PR DESCRIPTION
For more detail please see https://lgtm.com/rules/1506091066025/